### PR TITLE
Override Fixed blanks & Clean HDMI setting until VI generates a frame

### DIFF
--- a/N64.sv
+++ b/N64.sv
@@ -189,7 +189,7 @@ assign {SD_SCK, SD_MOSI, SD_CS} = 'Z;
 assign {SDRAM_DQ, SDRAM_A, SDRAM_BA, SDRAM_CLK, SDRAM_CKE, SDRAM_DQML, SDRAM_DQMH, SDRAM_nWE, SDRAM_nCAS, SDRAM_nRAS, SDRAM_nCS} = 'Z;
 
 assign FB_BASE    = video_FB_base;
-assign FB_EN      = status[105];
+assign FB_EN      = video_FB_en;
 assign FB_FORMAT  = 5'b00110;
 assign FB_WIDTH   = {2'd0, video_FB_sizeX};
 assign FB_HEIGHT  = {2'd0, video_FB_sizeY};
@@ -415,8 +415,12 @@ wire [24:0] mouse;
 
 wire [10:0] ps2_key;
 
+wire        fixed_blanks_off = status[82];
+wire        clean_hdmi = status[105];
+wire        video_FB_en;
+
 wire [127:0] status_in = {status[127:40],ss_slot,status[37:0]};
-wire [15:0] status_menumask = {14'd0, status[105], status[82]};
+wire [15:0] status_menumask = {14'd0, clean_hdmi, fixed_blanks_off};
 
 wire DIRECT_VIDEO;
 
@@ -730,7 +734,8 @@ n64top
    .fpscountOn(status[28]),
    
    .ISPAL(status[79]),
-   .FIXEDBLANKS(~status[82] && ~status[105]),
+   .FIXEDBLANKS(~fixed_blanks_off && ~clean_hdmi),
+   
    .CROPVERTICAL(status[45:44]),
    .VI_BILINEAROFF(status[32]),
    .VI_DEBLUR(status[89]),
@@ -741,7 +746,7 @@ n64top
    .VI_DIVOTOFF(status[36]),
    .VI_NOISEOFF(status[37]),
    .VI_7BITPERCOLOR(~status[104]),
-   .VI_DIRECTFBMODE(status[105]),
+   .VI_DIRECTFBMODE(clean_hdmi),
    
    .CICTYPE(status[68:65]),
    .RAMSIZE8(~status[70]),
@@ -891,14 +896,15 @@ n64top
    .video_g          (VGA_G),
    .video_b          (VGA_B),
    
+   .video_FB_en      (video_FB_en),
    .video_FB_base    (video_FB_base),
    .video_FB_sizeX   (video_FB_sizeX),
    .video_FB_sizeY   (video_FB_sizeY)
 );
 
 assign CLK_VIDEO = clk_vid;
-assign VGA_DE = status[105] ? 1'b0 : ~(HBlank | VBlank);
-assign VGA_F1 = status[105] ? 1'b0 : Interlaced ^ status[1];
+assign VGA_DE = ~(HBlank | VBlank);
+assign VGA_F1 = clean_hdmi ? 1'b0 : Interlaced ^ status[1];
 assign VGA_SL = 0;
 assign VGA_DISABLE = 0;
 
@@ -908,7 +914,7 @@ reg [11:0] ARCoreX = 12'd4;
 reg [11:0] ARCoreY = 12'd3;
    
 always @(posedge clk_1x) begin
-   if (status[82] || status[105]) begin // fixed blanks off
+   if (fixed_blanks_off || clean_hdmi) begin // fixed blanks off
       ARCoreX <= 12'd4;
       ARCoreY <= 12'd3;
    end else begin

--- a/rtl/VI.vhd
+++ b/rtl/VI.vhd
@@ -73,6 +73,7 @@ entity VI is
       video_g          : out std_logic_vector(7 downto 0);
       video_b          : out std_logic_vector(7 downto 0);
       
+      video_FB_en      : out std_logic;
       video_FB_base    : out unsigned(31 downto 0);
       video_FB_sizeX   : out unsigned(9 downto 0);
       video_FB_sizeY   : out unsigned(9 downto 0);
@@ -458,6 +459,7 @@ begin
       video_b                          => video_b,
       
       video_blockVIFB                  => video_blockVIFB,
+      video_FB_en                      => video_FB_en,
       video_FB_base                    => video_FB_base,
       video_FB_sizeX                   => video_FB_sizeX,
       video_FB_sizeY                   => video_FB_sizeY,

--- a/rtl/VI_package.vhd
+++ b/rtl/VI_package.vhd
@@ -8,6 +8,7 @@ package pVI is
       CTRL_TYPE         : unsigned(1 downto 0);
       CTRL_SERRATE      : std_logic;
       isPAL             : std_logic;
+      VI_DIRECTFBMODE   : std_logic;
       fixedBlanks       : std_logic;
       CROPVERTICAL      : unsigned(1 downto 0);
       videoSizeY        : unsigned(9 downto 0);

--- a/rtl/VI_videoout_async.vhd
+++ b/rtl/VI_videoout_async.vhd
@@ -313,6 +313,7 @@ begin
                   videoout_out.g      <= overlay_data(15 downto 8);
                   videoout_out.b      <= overlay_data(23 downto 16);
                elsif (videoout_settings.CTRL_TYPE(1) = '0' or 
+                      videoout_settings.VI_DIRECTFBMODE = '1' or
                       hpos(11 downto 2) < VIDEO_H_START or hpos(11 downto 2) >= VIDEO_H_END or 
                       vpos < VIDEO_V_START or vpos >= VIDEO_V_END) then
                   videoout_out.r      <= (others => '0');

--- a/rtl/n64top.vhd
+++ b/rtl/n64top.vhd
@@ -186,6 +186,7 @@ entity n64top is
       video_g                 : out std_logic_vector(7 downto 0);
       video_b                 : out std_logic_vector(7 downto 0);
       
+      video_FB_en             : out std_logic;
       video_FB_base           : out unsigned(31 downto 0);
       video_FB_sizeX          : out unsigned(9 downto 0);
       video_FB_sizeY          : out unsigned(9 downto 0)
@@ -869,6 +870,7 @@ begin
       video_g              => video_g,      
       video_b              => video_b,
       
+      video_FB_en          => video_FB_en,
       video_FB_base        => video_FB_base,
       video_FB_sizeX       => video_FB_sizeX,
       video_FB_sizeY       => video_FB_sizeY,


### PR DESCRIPTION
This should keep Fixed blanks on and Clean HDMI off until newFrame = 1.

DE is still generated with Clean HDMI so that the OSD shows up on Analog video output.  Videoout_async has been changed to output color black when Clean HDMI is on.